### PR TITLE
Add support for building map2D_nws_ros2 as part of the main CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp-ros2 is always built with dynamic plugins")
 set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build libraries as shared as opposed to static")
 
+option(YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs "If ON, use map2d_nws_ros2_msgs found in the system, otherwise build it with this project." ON)
+
 include(AddInstallRPATHSupport)
 add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"
                           LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"
@@ -60,9 +62,17 @@ find_package(sensor_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_msgs REQUIRED)
 find_package(test_msgs REQUIRED)
-find_package(map2d_nws_ros2_msgs REQUIRED)
+
 find_package(visualization_msgs REQUIRED)
 
+if(YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs)
+  find_package(map2d_nws_ros2_msgs REQUIRED)
+else()
+  add_subdirectory(ros2_interfaces_ws/src/map2d_nws_ros2_msgs)
+  if(NOT TARGET map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
+    add_library(map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp ALIAS map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
+  endif()
+endif()
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if(YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs)
   find_package(map2d_nws_ros2_msgs REQUIRED)
 else()
   add_subdirectory(ros2_interfaces_ws/src/map2d_nws_ros2_msgs)
+  # Temporary workaround for https://github.com/ament/ament_cmake/pull/349
   if(NOT TARGET map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
     add_library(map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp ALIAS map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,6 @@ if(YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs)
   find_package(map2d_nws_ros2_msgs REQUIRED)
 else()
   add_subdirectory(ros2_interfaces_ws/src/map2d_nws_ros2_msgs)
-  # Temporary workaround for https://github.com/ament/ament_cmake/pull/349
-  if(NOT TARGET map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
-    add_library(map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp ALIAS map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
-  endif()
 endif()
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This is a work in progress.
 
 This repository contains the YARP devices and utilities for ROS2.
 
-### Build
-
+### Build with ROS msgs compiled in separate colcon workspace
 
 ~~~bash
 # Compile the colcon workspace containing the required messages and services
@@ -19,3 +18,16 @@ This repository contains the YARP devices and utilities for ROS2.
 cmake -S. -Bbuild
 cmake --build build
 ~~~
+
+### Build with pure CMake commands
+
+~~~
+# Configure, compile and install
+cmake -S. -Bbuild -DCMAKE_INSTALL_PREFIX=<install_prefix>
+cmake --build build
+cmake --build build --target install
+
+# Make ROS msgs available in [ament index](https://github.com/ament/ament_index)
+export AMENT_PREFIX_PATH=$AMENT_PREFIX_PATH:<install_prefix>
+~~~
+

--- a/ros2_interfaces_ws/src/map2d_nws_ros2_msgs/CMakeLists.txt
+++ b/ros2_interfaces_ws/src/map2d_nws_ros2_msgs/CMakeLists.txt
@@ -47,3 +47,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 ament_export_dependencies(rosidl_default_runtime)
 
 ament_package()
+
+# Temporary workaround for https://github.com/ros2/rosidl/pull/605
+if(NOT TARGET map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
+  add_library(map2d_nws_ros2_msgs::map2d_nws_ros2_msgs__rosidl_typesupport_cpp ALIAS map2d_nws_ros2_msgs__rosidl_typesupport_cpp)
+endif()

--- a/src/devices/map2D_nws_ros2/CMakeLists.txt
+++ b/src/devices/map2D_nws_ros2/CMakeLists.txt
@@ -6,7 +6,9 @@
 
 find_package(nav_msgs REQUIRED)
 find_package(test_msgs REQUIRED)
-find_package(map2d_nws_ros2_msgs REQUIRED)
+if(YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs)
+  find_package(map2d_nws_ros2_msgs REQUIRED)
+endif()
 find_package(visualization_msgs REQUIRED)
 
 yarp_prepare_plugin(map2D_nws_ros2


### PR DESCRIPTION
Fix https://github.com/robotology-playground/yarp-ros2/issues/6 . For the time being I added this modification behind an option `YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs`, whose default value is `ON`, so the default behaviour does not change. The main use case for this modification is to eventually include this repository in the robotology-superbuild, where by the way the `AMENT_PREFIX_PATH` value is already set: https://github.com/robotology/robotology-superbuild/blob/master/cmake/template/setup.sh.in#L28 .