### PR TITLE
Add workflow_dispatch to CI job and fix Windows CI job

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         build_type: [Release]
         ros_distro: [galactic]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2019, macos-latest]
       fail-fast: false
 
     steps:

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -3,6 +3,7 @@ name: C++ CI Workflow with conda dependencies
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
   # * is a special character in YAML so you have to quote this string
   # Execute a "nightly" build at 2 AM UTC


### PR DESCRIPTION
Sometimes it is useful to check if the repo is working against the latest version of the ROS2 packages even if nothing changed in the repo.