### PR TITLE
Enable Windows in CI

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -117,7 +117,7 @@ jobs:
         # Workaround for https://github.com/RoboStack/ros-galactic/issues/39
         unset DYLD_LIBRARY_PATH
         cd build
-        cmake --install --config ${{ matrix.build_type }}
+        cmake --install . --config ${{ matrix.build_type }}
   
     - name: Build [Windows]
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         build_type: [Release]
         ros_distro: [humble]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
       fail-fast: false
 
     steps:

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -81,7 +81,7 @@ jobs:
         cd build
         # Python3_EXECUTABLE is set as a workaround for https://github.com/ros2/python_cmake_module/issues/6
         cmake -GNinja -DBUILD_TESTING:BOOL=ON -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF \
-              -DPython3_EXECUTABLE:PATH=$CONDA_PREFIX/bin/python3 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+              -DPython3_EXECUTABLE:PATH=$CONDA_PREFIX/bin/python3 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=./install ..
 
     - name: Configure [Windows]
       if: contains(matrix.os, 'windows')
@@ -90,7 +90,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON -DYARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs:BOOL=OFF -DPython3_EXECUTABLE:PATH=%CONDA_PREFIX%\python.exe -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=.\install ..
 
     - name: Build [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -109,7 +109,15 @@ jobs:
         unset DYLD_LIBRARY_PATH
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
-        
+
+    - name: Install [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        # Workaround for https://github.com/RoboStack/ros-galactic/issues/39
+        unset DYLD_LIBRARY_PATH
+        cd build
+        cmake --install --config ${{ matrix.build_type }}
   
     - name: Build [Windows]
       if: contains(matrix.os, 'windows')
@@ -124,3 +132,10 @@ jobs:
       run: |
         cd build
         ctest --output-on-failure -C ${{ matrix.build_type }}
+
+    - name: Install [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: cmd /C CALL {0}
+      run: |
+        cd build
+        cmake --install . --config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(YARP_FORCE_DYNAMIC_PLUGINS TRUE CACHE INTERNAL "yarp-ros2 is always built with dynamic plugins")
-set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build libraries as shared as opposed to static")
+option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 
 option(YARP_ROS2_USE_SYSTEM_map2d_nws_ros2_msgs "If ON, use map2d_nws_ros2_msgs found in the system, otherwise build it with this project." ON)
 

--- a/src/devices/odometry2D_nws_ros2/Odometry2D_nws_ros2.cpp
+++ b/src/devices/odometry2D_nws_ros2/Odometry2D_nws_ros2.cpp
@@ -2,6 +2,9 @@
  * SPDX-FileCopyrightText: 2006-2021 Istituto Italiano di Tecnologia (IIT)
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
+
+// For M_PI
+#define _USE_MATH_DEFINES
 #include "Odometry2D_nws_ros2.h"
 #include <yarp/os/LogComponent.h>
 #include <yarp/os/LogStream.h>


### PR DESCRIPTION
To fix Windows compilation on ROS Humble, this PR:
* Adds `#define _USE_MATH_DEFINES` to permit to use `M_PI`,
* Switch to use `BUILD_SHARED_LIBS` set to `ON` by default. This is not strictly necessary, but it is done to workaround a bug in `rosidl_typesupport_fastrtps_cpp` and `rosidl_typesupport_fastrtps_c` on ROS Humble when when  `BUILD_SHARED_LIBS` is set to `OFF`, see https://github.com/RoboStack/ros-humble/issues/1 . 